### PR TITLE
20 - Enable Security Hub for ORG

### DIFF
--- a/audit/global/global/org_security_hub.tf
+++ b/audit/global/global/org_security_hub.tf
@@ -1,0 +1,51 @@
+resource "aws_securityhub_account" "us_east_1" {}
+
+resource "aws_securityhub_standards_subscription" "cis_us_east_1" {
+  depends_on    = [aws_securityhub_account.us_east_1]
+  standards_arn = "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0"
+}
+
+resource "aws_securityhub_standards_subscription" "aws_foundational_us_east_1" {
+  depends_on    = [aws_securityhub_account.us_east_1]
+  standards_arn = "arn:aws:securityhub:us-east-1::standards/aws-foundational-security-best-practices/v/1.0.0"
+}
+
+resource "aws_securityhub_account" "us_west_2" {
+  provider = aws.west
+}
+
+resource "aws_securityhub_standards_subscription" "cis_us_west_2" {
+  depends_on    = [aws_securityhub_account.us_west_2]
+  standards_arn = "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0"
+  provider      = aws.west
+}
+
+resource "aws_securityhub_standards_subscription" "aws_foundational_us_west_2" {
+  depends_on    = [aws_securityhub_account.us_west_2]
+  standards_arn = "arn:aws:securityhub:us-west-2::standards/aws-foundational-security-best-practices/v/1.0.0"
+  provider      = aws.west
+}
+
+resource "null_resource" "security_hub_delegation_us_east_1" {
+  provisioner "local-exec" {
+    command = <<EOF
+aws securityhub update-organization-configuration --auto-enable --profile audit-super-user --region us-east-1
+EOF
+    environment = {
+      ACCOUNT_ID = local.aws_account_id
+      REGION     = "us-east-1"
+    }
+  }
+}
+
+resource "null_resource" "security_hub_delegation_us_west_2" {
+  provisioner "local-exec" {
+    command = <<EOF
+aws securityhub update-organization-configuration --auto-enable --profile audit-super-user --region us-west-2
+EOF
+    environment = {
+      ACCOUNT_ID = local.aws_account_id
+      REGION     = "us-west-2"
+    }
+  }
+}

--- a/bastion/global/accounts/accounts.tf
+++ b/bastion/global/accounts/accounts.tf
@@ -3,6 +3,7 @@ resource "aws_organizations_organization" "mob" {
     "cloudtrail.amazonaws.com",
     "config.amazonaws.com",
     "config-multiaccountsetup.amazonaws.com",
+    "securityhub.amazonaws.com",
   ]
 
   feature_set = "ALL"

--- a/bastion/global/global/security_hub.tf
+++ b/bastion/global/global/security_hub.tf
@@ -1,0 +1,27 @@
+resource "aws_securityhub_account" "us_east_1" {}
+
+resource "aws_securityhub_standards_subscription" "cis_us_east_1" {
+  depends_on    = [aws_securityhub_account.us_east_1]
+  standards_arn = "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0"
+}
+
+resource "aws_securityhub_standards_subscription" "aws_foundational_us_east_1" {
+  depends_on    = [aws_securityhub_account.us_east_1]
+  standards_arn = "arn:aws:securityhub:us-east-1::standards/aws-foundational-security-best-practices/v/1.0.0"
+}
+
+resource "aws_securityhub_account" "us_west_2" {
+  provider = aws.west
+}
+
+resource "aws_securityhub_standards_subscription" "cis_us_west_2" {
+  depends_on    = [aws_securityhub_account.us_west_2]
+  standards_arn = "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0"
+  provider      = aws.west
+}
+
+resource "aws_securityhub_standards_subscription" "aws_foundational_us_west_2" {
+  depends_on    = [aws_securityhub_account.us_west_2]
+  standards_arn = "arn:aws:securityhub:us-west-2::standards/aws-foundational-security-best-practices/v/1.0.0"
+  provider      = aws.west
+}


### PR DESCRIPTION
## Security Hub for Organization accounts

Enable organization accounts as Security Hub member accounts.

- Subscribe every account and every region we need to the Security Hub service (this PR)

- Configure the Security Hub administrator account. The Security Hub administrator account must be the same in all Regions
    `aws securityhub enable-organization-admin-account --admin-account-id <AUDIT_ACCOUNT>`
- Automatically enable new organization accounts as they are added to the organization.
    `aws securityhub update-organization-configuration --auto-enable`
- Disassociate accounts that belong to the organization. They cannot delete organization accounts.

https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-settingup.html