### PR TITLE
90 - Create an IAM role to Integrate API GW with CloudWatch

### DIFF
--- a/production/global/global/cloudwatch.tf
+++ b/production/global/global/cloudwatch.tf
@@ -1,0 +1,54 @@
+###
+# IAM role to support API Gateway and CloudWatch integration
+###
+
+resource "aws_api_gateway_account" "global_logs" {
+  cloudwatch_role_arn = aws_iam_role.api_gateway_cloudwatch.arn
+}
+
+data "aws_iam_policy_document" "assume_role_policy" {
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["apigateway.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "api_gateway_cloudwatch" {
+  name               = module.apigw_logs_label.id
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+  tags               = module.apigw_logs_label.tags
+}
+
+resource "aws_iam_role_policy" "api_gateway_cloudwatch_role_policy" {
+  name   = "${module.apigw_logs_label.id}-policy"
+  role   = aws_iam_role.api_gateway_cloudwatch.id
+  policy = data.aws_iam_policy_document.api_gateway_cloudwatch_policy.json
+}
+
+data "aws_iam_policy_document" "api_gateway_cloudwatch_policy" {
+
+  statement {
+    sid    = "APIGatewayCloudwatch"
+    effect = "Allow"
+
+    resources = [
+      "*"
+    ]
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents",
+      "logs:GetLogEvents",
+      "logs:FilterLogEvents",
+    ]
+  }
+}

--- a/production/global/global/labels.tf
+++ b/production/global/global/labels.tf
@@ -4,3 +4,9 @@ module "label" {
   name        = local.role_name
   team        = local.team
 }
+
+module "apigw_logs_label" {
+  source     = "../../../modules/base/label/v1"
+  context    = module.label.context
+  attributes = ["apigateway", "cloudwatch"]
+}


### PR DESCRIPTION
Hotfix for #86


```

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_api_gateway_account.global_logs will be created
  + resource "aws_api_gateway_account" "global_logs" {
      + cloudwatch_role_arn = (known after apply)
      + id                  = (known after apply)
      + throttle_settings   = (known after apply)
    }

  # aws_iam_role.api_gateway_cloudwatch will be created
  + resource "aws_iam_role" "api_gateway_cloudwatch" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "apigateway.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "production-global-apigateway-cloudwatch"
      + path                  = "/"
      + tags                  = {
          + "Name"        = "production-global-apigateway-cloudwatch"
          + "attributes"  = "apigateway-cloudwatch"
          + "environment" = "production"
          + "repo"        = "aws-sandbox-terraform/production/global/global"
          + "role"        = "global"
          + "team"        = "ops"
        }
      + tags_all              = {
          + "Name"        = "production-global-apigateway-cloudwatch"
          + "attributes"  = "apigateway-cloudwatch"
          + "environment" = "production"
          + "repo"        = "aws-sandbox-terraform/production/global/global"
          + "role"        = "global"
          + "team"        = "ops"
        }
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # aws_iam_role_policy.api_gateway_cloudwatch_role_policy will be created
  + resource "aws_iam_role_policy" "api_gateway_cloudwatch_role_policy" {
      + id     = (known after apply)
      + name   = "production-global-apigateway-cloudwatch-policy"
      + policy = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "logs:PutLogEvents",
                          + "logs:GetLogEvents",
                          + "logs:FilterLogEvents",
                          + "logs:DescribeLogStreams",
                          + "logs:DescribeLogGroups",
                          + "logs:CreateLogStream",
                          + "logs:CreateLogGroup",
                        ]
                      + Effect   = "Allow"
                      + Resource = "*"
                      + Sid      = "APIGatewayCloudwatch"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + role   = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.
=======================================================
```