### PR TITLE
Add SCP deny IAM CreateAccessKey (Resolves #52)

### DIFF
--- a/bastion/global/accounts/scp.tf
+++ b/bastion/global/accounts/scp.tf
@@ -5,6 +5,7 @@
 data "aws_iam_policy_document" "scp" {
   source_policy_documents = [
     data.aws_iam_policy_document.deny_disallowed_regions.json,
+    data.aws_iam_policy_document.deny_iam_create_access_key.json,
     data.aws_iam_policy_document.deny_root_access.json,
     data.aws_iam_policy_document.deny_org_leave.json,
     data.aws_iam_policy_document.immutable_admin_role.json,

--- a/bastion/global/accounts/scp_deny_iam_create_access_key.tf
+++ b/bastion/global/accounts/scp_deny_iam_create_access_key.tf
@@ -1,0 +1,27 @@
+# Deny ability to create IAM access keys unless it's a superuser
+data "aws_iam_policy_document" "deny_iam_create_access_key" {
+  statement {
+    sid = "DenyIamCreateAccessKey"
+
+    actions = [
+      "iam:CreateAccessKey"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    effect = "Deny"
+
+    condition {
+      test     = "StringNotLike"
+      variable = "aws:PrincipalARN"
+
+      values = [
+        "arn:aws:iam::*:role/super-user"
+      ]
+    }
+
+  }
+}
+


### PR DESCRIPTION
<details><summary>TF plan</summary>

```diff

Terraform will perform the following actions:
              + {
                  + Action    = "iam:CreateAccessKey"
                  + Condition = {
                      + StringNotLike = {
                          + aws:PrincipalARN = [
                              + "arn:aws:iam::*:role/super-user",
                            ]
                        }
                    }
                  + Effect    = "Deny"
                  + Resource  = "*"
                  + Sid       = "DenyIamCreateAccessKey"
                },

```
</details>