### PR TITLE
Revert S3 SCP

### DIFF
--- a/bastion/global/accounts/scp_protect_security_settings.tf
+++ b/bastion/global/accounts/scp_protect_security_settings.tf
@@ -21,20 +21,4 @@ data "aws_iam_policy_document" "security_settings" {
       values   = ["false"]
     }
   }
-
-  statement {
-    sid = "PreventModifyingS3PublicAccessBlock"
-    actions = [
-      "s3:PutBucketPublicAccessBlock"
-    ]
-    resources = ["*"]
-    effect    = "Deny"
-    condition {
-      test     = "StringNotLike"
-      variable = "aws:PrincipalARN"
-      values = [
-        "arn:aws:iam::*:role/super-user"
-      ]
-    }
-  }
 }


### PR DESCRIPTION
Reverted due to we can't create S3 buckets via Terraform

Having an error 
```
module.website.module.dns[0].aws_route53_record.default[0]: Creation complete after 32s [id=Z10035952CIDYBP7F6X90_cloudology.by_A]

Error: error creating public access block policy for S3 bucket (cloudology.by): AccessDenied: Access Denied
        status code: 403, request id: HQG91Z28HGSX4EE5, host id: Blq7Wj5v6Edu0zfrkeXAEcRDiKJ4+skAHdgkSq61p+HGxW4x2cBidCneuRVIAjb5CMjew/z45B4=

  on ../../../modules/base/s3-website/v1/main.tf line 204, in resource "aws_s3_bucket_public_access_block" "default":
 204: resource "aws_s3_bucket_public_access_block" "default" {

```