### PR TITLE
116 - Add machine_user to Production env

### DIFF
--- a/bastion/global/global/policies.tf
+++ b/bastion/global/global/policies.tf
@@ -223,8 +223,8 @@ data "aws_iam_policy_document" "developer_permissions" {
     ]
 
     resources = [
-      "arn:aws:s3:::sb-production-serverless*",
-      "arn:aws:s3:::sb-production-serverless*/*",
+      "arn:aws:s3:::${var.terraform_remote_state_serverless_bucket}*",
+      "arn:aws:s3:::${var.terraform_remote_state_serverless_bucket}*/*",
     ]
   }
 
@@ -273,8 +273,8 @@ data "aws_iam_policy_document" "ops_role_iam" {
     ]
 
     resources = [
-      "arn:aws:s3:::mob-terraform-state/",
-      "arn:aws:s3:::mob-terraform-state/*",
+      "arn:aws:s3:::${var.terraform_remote_state_bucket}",
+      "arn:aws:s3:::${var.terraform_remote_state_bucket}/*",
     ]
   }
 }

--- a/global-variables.tf.json
+++ b/global-variables.tf.json
@@ -134,6 +134,10 @@
     "terraform_remote_state_region": {
       "default": "us-east-1",
       "description": "Terraform remote s3 storage region"
+    },
+    "terraform_remote_state_serverless_bucket": {
+      "default": "sb-production-serverless",
+      "description": "Terraform remote serverless s3 bucket for production"
     }
   }
 }

--- a/production/global/global/iam.tf
+++ b/production/global/global/iam.tf
@@ -1,0 +1,138 @@
+### CI/CD ###
+
+resource "aws_iam_user" "machine_user" {
+  name          = local.machine_user_name
+  path          = "/terraform/"
+  force_destroy = true
+  tags          = module.machine_user_label.tags
+}
+
+### Give Machine user power
+
+data "aws_iam_policy_document" "machine_secrets" {
+  statement {
+    actions   = ["ssm:GetParameter", "ssm:GetParameters"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "ssm:ResourceTag/role"
+      values   = [local.machine_user_name]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "ssm:ResourceTag/environment"
+      values   = [var.account_name]
+    }
+
+    effect = "Allow"
+  }
+
+  dynamic "statement" {
+    for_each = aws_iam_user.machine_user.*.name
+    content {
+      actions   = ["ssm:GetParameter", "ssm:GetParameters"]
+      resources = ["*"]
+
+      condition {
+        test     = "StringEquals"
+        variable = "ssm:ResourceTag/username"
+        values   = [statement.value]
+      }
+    }
+  }
+
+}
+
+resource "aws_iam_policy" "machine_secrets" {
+  name        = "machine-secrets"
+  description = "Machine user policy to read its secrets"
+  policy      = data.aws_iam_policy_document.machine_secrets.json
+  tags        = module.machine_user_label.tags
+}
+
+resource "aws_iam_group_policy_attachment" "machine_secrets" {
+  group      = "automation"
+  policy_arn = aws_iam_policy.machine_secrets.arn
+}
+
+### END CI/CD ##
+
+### AUTOMATION ###
+
+resource "aws_iam_group" "automation" {
+  name = "automation"
+  path = "/terraform/"
+}
+
+resource "aws_iam_group_membership" "automation" {
+  name  = "automation"
+  users = [aws_iam_user.machine_user.name]
+  group = aws_iam_group.automation.name
+}
+
+resource "aws_iam_group_policy_attachment" "read_only_access" {
+  group      = "automation"
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+data "aws_iam_policy_document" "machine_assumerole_terraform_github" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${var.aws_account_map["bastion"]}:root",
+        aws_iam_user.machine_user.arn,
+        "arn:aws:iam::${var.aws_account_map["production"]}:role/ops",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "terraform_github" {
+  name               = "terraform-github-state-editor"
+  path               = "/terraform/"
+  assume_role_policy = data.aws_iam_policy_document.machine_assumerole_terraform_github.json
+  tags               = module.label.tags
+}
+
+data "aws_iam_policy_document" "terraform_state_access" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:List*",
+      "s3:Get*",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.terraform_remote_state_bucket}",
+      "arn:aws:s3:::${var.terraform_remote_state_bucket}/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:Put*",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.terraform_remote_state_bucket}/github",
+      "arn:aws:s3:::${var.terraform_remote_state_bucket}/github/*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "terraform_github_state_editor" {
+  name   = "terraform-github-state-bucket-rw"
+  role   = aws_iam_role.terraform_github.id
+  policy = data.aws_iam_policy_document.terraform_state_access.json
+}
+
+### END AUTOMATION ###

--- a/production/global/global/iam.tf
+++ b/production/global/global/iam.tf
@@ -116,17 +116,69 @@ data "aws_iam_policy_document" "terraform_state_access" {
   }
 
   statement {
+    sid    = "AllowGitHubActionsLambda"
     effect = "Allow"
 
     actions = [
-      "s3:Put*",
+      "lambda:CreateFunction",
+      "lambda:DeleteFunction",
+      "lambda:Get*",
+      "lambda:InvokeFunction",
+      "lambda:List*",
+      "lambda:Publish*",
+      "lambda:UpdateAlias",
+      "lambda:UpdateFunctionCode",
+    ]
+
+    resources = [
+      "arn:aws:lambda:*:*:function:aws-sandbox-serverless*",
+    ]
+  }
+
+  statement {
+    sid    = "AllowGitHubActionsS3"
+    effect = "Allow"
+
+    actions = [
+      "s3:DeleteObject*",
+      "s3:GetObject*",
+      "s3:List*",
+      "s3:PutObject*",
     ]
 
     resources = [
       "arn:aws:s3:::${var.terraform_remote_state_bucket}/github",
       "arn:aws:s3:::${var.terraform_remote_state_bucket}/github/*",
+      "arn:aws:s3:::${var.terraform_remote_state_serverless_bucket}*",
+      "arn:aws:s3:::${var.terraform_remote_state_serverless_bucket}*/*",
+      "arn:aws:s3:::cloudology.by",
     ]
   }
+
+  statement {
+    sid    = "AllowGitHubActionsECR"
+    effect = "Allow"
+
+    actions = [
+      "ecr:CompleteLayerUpload",
+      "ecr:BatchGet*",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:Describe*",
+      "ecr:Get*",
+      "ecr:InitiateLayerUpload",
+      "ecr:List*",
+      "ecr:PutImage",
+      "ecr:TagResource",
+      "ecr:UntagResource",
+      "ecr:UploadLayerPart",
+    ]
+
+    /* TODO: update ARN for existing ECR */
+    /* resource = [ */
+    /*     "arn:${Partition}:ecr:${Region}:${Account}:repository/${RepositoryName}" */
+    /* ] */
+  }
+
 }
 
 resource "aws_iam_role_policy" "terraform_github_state_editor" {

--- a/production/global/global/labels.tf
+++ b/production/global/global/labels.tf
@@ -17,3 +17,9 @@ module "apigw_logs_label" {
   context    = module.label.context
   attributes = ["apigateway", "cloudwatch"]
 }
+
+module "machine_user_label" {
+  source  = "../../../modules/base/label/v1"
+  context = module.label.context
+  name    = "machine"
+}

--- a/production/global/global/locals.tf
+++ b/production/global/global/locals.tf
@@ -2,6 +2,8 @@ locals {
   role_name = "global"
   team      = "ops"
 
+  machine_user_name = "machine_user"
+
   aws_log_delivery_service_enabled    = false
   aws_elb_logging_enabled             = false
   aws_cloudwatch_logs_service_enabled = true


### PR DESCRIPTION
<details><summary>TF plan</summary>

```diff

Terraform will perform the following actions:

  # data.aws_iam_policy_document.machine_assumerole_terraform_github will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "machine_assumerole_terraform_github"  {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions = [
              + "sts:AssumeRole",
            ]
          + effect  = "Allow"

          + principals {
              + identifiers = [
                  + "arn:aws:iam::501055688096:root",
                  + "arn:aws:iam::562495469185:role/ops",
                  + (known after apply),
                ]
              + type        = "AWS"
            }
        }
    }

  # aws_iam_group.automation will be created
  + resource "aws_iam_group" "automation" {
      + arn       = (known after apply)
      + id        = (known after apply)
      + name      = "automation"
      + path      = "/terraform/"
      + unique_id = (known after apply)
    }

  # aws_iam_group_membership.automation will be created
  + resource "aws_iam_group_membership" "automation" {
      + group = "automation"
      + id    = (known after apply)
      + name  = "automation"
      + users = [
          + "machine_user",
        ]
    }

  # aws_iam_group_policy_attachment.machine_secrets will be created
  + resource "aws_iam_group_policy_attachment" "machine_secrets" {
      + group      = "automation"
      + id         = (known after apply)
      + policy_arn = (known after apply)
    }

  # aws_iam_group_policy_attachment.read_only_access will be created
  + resource "aws_iam_group_policy_attachment" "read_only_access" {
      + group      = "automation"
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
    }

  # aws_iam_policy.machine_secrets will be created
  + resource "aws_iam_policy" "machine_secrets" {
      + arn         = (known after apply)
      + description = "Machine user policy to read its secrets"
      + id          = (known after apply)
      + name        = "machine-secrets"
      + path        = "/"
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = [
                          + "ssm:GetParameters",
                          + "ssm:GetParameter",
                        ]
                      + Condition = {
                          + StringEquals = {
                              + ssm:ResourceTag/environment = "production"
                              + ssm:ResourceTag/role        = "machine_user"
                            }
                        }
                      + Effect    = "Allow"
                      + Resource  = "*"
                      + Sid       = ""
                    },
                  + {
                      + Action    = [
                          + "ssm:GetParameters",
                          + "ssm:GetParameter",
                        ]
                      + Condition = {
                          + StringEquals = {
                              + ssm:ResourceTag/username = "machine_user"
                            }
                        }
                      + Effect    = "Allow"
                      + Resource  = "*"
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id   = (known after apply)
      + tags        = {
          + "Name"        = "production-machine"
          + "environment" = "production"
          + "repo"        = "aws-sandbox-terraform/production/global/global"
          + "role"        = "machine"
          + "team"        = "ops"
        }
      + tags_all    = {
          + "Name"        = "production-machine"
          + "environment" = "production"
          + "repo"        = "aws-sandbox-terraform/production/global/global"
          + "role"        = "machine"
          + "team"        = "ops"
        }
    }

  # aws_iam_role.terraform_github will be created
  + resource "aws_iam_role" "terraform_github" {
      + arn                   = (known after apply)
      + assume_role_policy    = (known after apply)
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "terraform-github-state-editor"
      + name_prefix           = (known after apply)
      + path                  = "/terraform/"
      + tags                  = {
          + "Name"        = "production-global"
          + "environment" = "production"
          + "repo"        = "aws-sandbox-terraform/production/global/global"
          + "role"        = "global"
          + "team"        = "ops"
        }
      + tags_all              = {
          + "Name"        = "production-global"
          + "environment" = "production"
          + "repo"        = "aws-sandbox-terraform/production/global/global"
          + "role"        = "global"
          + "team"        = "ops"
        }
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # aws_iam_role_policy.terraform_github_state_editor will be created
  + resource "aws_iam_role_policy" "terraform_github_state_editor" {
      + id     = (known after apply)
      + name   = "terraform-github-state-bucket-rw"
      + policy = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "s3:List*",
                          + "s3:Get*",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:s3:::mob-terraform-state/*",
                          + "arn:aws:s3:::mob-terraform-state",
                        ]
                      + Sid      = ""
                    },
                  + {
                      + Action   = "s3:Put*"
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:s3:::mob-terraform-state/github/*",
                          + "arn:aws:s3:::mob-terraform-state/github",
                        ]
                      + Sid      = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + role   = (known after apply)
    }

  # aws_iam_user.machine_user will be created
  + resource "aws_iam_user" "machine_user" {
      + arn           = (known after apply)
      + force_destroy = true
      + id            = (known after apply)
      + name          = "machine_user"
      + path          = "/terraform/"
      + tags          = {
          + "Name"        = "production-machine"
          + "environment" = "production"
          + "repo"        = "aws-sandbox-terraform/production/global/global"
          + "role"        = "machine"
          + "team"        = "ops"
        }
      + tags_all      = {
          + "Name"        = "production-machine"
          + "environment" = "production"
          + "repo"        = "aws-sandbox-terraform/production/global/global"
          + "role"        = "machine"
          + "team"        = "ops"
        }
      + unique_id     = (known after apply)
    }

Plan: 8 to add, 0 to change, 0 to destroy.


```
</details>
