### PR TITLE
112 - create ECR repo for Atlantis

### DIFF
--- a/modules/base/ecr/v1/README.md
+++ b/modules/base/ecr/v1/README.md
@@ -1,0 +1,29 @@
+## Purpose
+
+This role helps us create ECR repositories in a standardized way.
+
+## Usage
+
+### A new ECR
+```hcl
+module "label" {
+  source              = "../../../modules/base/label/v1"
+  environment         = local.env
+  name                = local.role_name
+  team                = local.team
+}
+
+module "atlantis_service" {
+  source         = "../../../modules/base/ecr/v1"
+  name           = "atlantis-service"
+  label          = module.label
+}
+```
+
+## History:
+### v1:
+- Initial version
+
+<!-- BEGINNING OF TERRAFORM-DOCS HOOK -->
+
+<!-- END OF TERRAFORM-DOCS HOOK -->

--- a/modules/base/ecr/v1/main.tf
+++ b/modules/base/ecr/v1/main.tf
@@ -1,0 +1,59 @@
+resource "aws_ecr_repository" "default" {
+  name = "${var.namespace}/${var.name}"
+  tags = var.label.tags
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "default" {
+  repository = aws_ecr_repository.default.name
+
+  policy = data.template_file.rules.rendered
+}
+
+data "aws_iam_policy_document" "cross_account_get_access" {
+  count = signum(length(var.cross_accounts))
+
+  statement {
+    sid = "AllowXAccountPush"
+
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:DescribeRepositories",
+      "ecr:DescribeImages",
+      "ecr:GetAuthorizationToken",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetrepositoryPolicy",
+      "ecr:ListImages"
+    ]
+
+    principals {
+      type = "AWS"
+
+      identifiers = formatlist("arn:aws:iam::%s:root", var.cross_accounts)
+    }
+  }
+  statement {
+    sid = "LambdaECRImageRetrievalPolicy"
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetRepositoryPolicy",
+      "ecr:SetRepositoryPolicy",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_ecr_repository_policy" "cross_account_get_access" {
+  count      = signum(length(var.cross_accounts))
+  repository = aws_ecr_repository.default.id
+  policy     = data.aws_iam_policy_document.cross_account_get_access[0].json
+}

--- a/modules/base/ecr/v1/output.tf
+++ b/modules/base/ecr/v1/output.tf
@@ -1,0 +1,18 @@
+output "registry_id" {
+  value       = aws_ecr_repository.default.registry_id
+  description = "Registry ID"
+}
+
+output "repository_url" {
+  value       = aws_ecr_repository.default.repository_url
+  description = "Repository URL"
+}
+
+output "repository_name" {
+  value       = aws_ecr_repository.default.name
+  description = "Repository name"
+}
+
+output "repository" {
+  value = aws_ecr_repository.default
+}

--- a/modules/base/ecr/v1/rules.json.tpl
+++ b/modules/base/ecr/v1/rules.json.tpl
@@ -1,0 +1,109 @@
+{
+  "rules": [
+    {
+      "action": {
+        "type": "expire"
+      },
+      "description": "Rotate images when reach ${max_image_count} images stored for hot-fixed images",
+      "rulePriority": 1,
+      "selection": {
+        "countNumber": ${max_image_count},
+        "countType": "imageCountMoreThan",
+        "tagPrefixList": [
+          "${staging_tag_prefix}",
+          "${prod_tag_prefix}",
+          "${version_tag_prefix}"
+        ],
+        "tagStatus": "tagged"
+      }
+    },
+    {
+      "action": {
+        "type": "expire"
+      },
+      "description": "Rotate images when reach ${max_image_count} images stored for production images",
+      "rulePriority": 2,
+      "selection": {
+        "countNumber": ${max_image_count},
+        "countType": "imageCountMoreThan",
+        "tagPrefixList": [
+          "${prod_tag_prefix}",
+          "${version_tag_prefix}"
+        ],
+        "tagStatus": "tagged"
+      }
+    },
+    {
+      "action": {
+        "type": "expire"
+      },
+      "description": "Rotate images when reach ${max_image_count} images stored for sole production tags",
+      "rulePriority": 3,
+      "selection": {
+        "countNumber": ${max_image_count},
+        "countType": "imageCountMoreThan",
+        "tagPrefixList": [
+          "${version_tag_prefix}"
+        ],
+        "tagStatus": "tagged"
+      }
+    },
+    {
+      "action": {
+        "type": "expire"
+      },
+      "description": "Rotate images when reach ${max_image_count} images stored for solo release tags",
+      "rulePriority": 4,
+      "selection": {
+        "countNumber": ${max_image_count},
+        "countType": "imageCountMoreThan",
+        "tagPrefixList": [
+          "${prod_tag_prefix}"
+        ],
+        "tagStatus": "tagged"
+      }
+    },
+    {
+      "action": {
+        "type": "expire"
+      },
+      "description": "Rotate images when reach ${max_image_count} images stored for candidate tags",
+      "rulePriority": 5,
+      "selection": {
+        "countNumber": ${max_image_count},
+        "countType": "imageCountMoreThan",
+        "tagPrefixList": [
+          "${staging_tag_prefix}"
+        ],
+        "tagStatus": "tagged"
+      }
+    },
+    {
+      "action": {
+        "type": "expire"
+      },
+      "description": "Rotate images when reach ${max_image_count} images stored for job images",
+      "rulePriority": 6,
+      "selection": {
+        "countNumber": ${max_image_count},
+        "countType": "imageCountMoreThan",
+        "tagPrefixList": [
+          "${job_tag_prefix}"
+        ],
+        "tagStatus": "tagged"
+      }
+    },
+    {
+      "action": {
+        "type": "expire"
+      },
+      "description": "Rotate image any other images",
+      "rulePriority": 7,
+      "selection": {
+        "countNumber": ${max_image_count},
+        "countType": "imageCountMoreThan",
+        "tagStatus": "any"
+      }
+    }
+  ]
+}

--- a/modules/base/ecr/v1/variables.tf
+++ b/modules/base/ecr/v1/variables.tf
@@ -1,0 +1,57 @@
+variable "name" {
+  description = "Name of service"
+}
+
+variable "namespace" {
+  description = "Namespace for repository. Use Sandbox for consistency if possible."
+  default     = "sandbox"
+}
+
+variable "staging_tag_prefix" {
+  description = "Prefix of staging tags to remove"
+  default     = "candidate"
+}
+
+variable "prod_tag_prefix" {
+  description = "Prefix of production tags to remove"
+  default     = "release"
+}
+
+variable "job_tag_prefix" {
+  description = "Prefix of one-time job tags to remove"
+  default     = "job"
+}
+
+variable "version_tag_prefix" {
+  description = "Prefix of one-time job tags to remove"
+  default     = "v"
+}
+
+variable "cross_accounts" {
+  type        = list(string)
+  default     = []
+  description = "Which accounts need to pull from ECR repo"
+}
+
+variable "max_image_count" {
+  type        = string
+  description = "Number of Docker Image versions AWS ECR will store"
+  default     = "50"
+}
+
+data "template_file" "rules" {
+  template = file("${path.module}/rules.json.tpl")
+
+  vars = {
+    max_image_count    = var.max_image_count
+    staging_tag_prefix = var.staging_tag_prefix
+    prod_tag_prefix    = var.prod_tag_prefix
+    job_tag_prefix     = var.job_tag_prefix
+    version_tag_prefix = var.version_tag_prefix
+  }
+}
+
+variable "label" {
+  type        = any
+  description = "Single `label` resource for setting context and tagging resources. Typically this will be something like `module.label`."
+}

--- a/modules/base/ecr/v1/versions.tf
+++ b/modules/base/ecr/v1/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.73.0"
+    }
+  }
+}

--- a/production/roles/atlantis/ecr.tf
+++ b/production/roles/atlantis/ecr.tf
@@ -1,0 +1,6 @@
+module "atlantis" {
+  source         = "../../../modules/base/ecr/v1"
+  label          = module.label
+  name           = "atlantis"
+  cross_accounts = [var.aws_account_map["production"]]
+}


### PR DESCRIPTION
<details><summary>TF plan</summary>

```diff

Terraform will perform the following actions:

  # module.atlantis.aws_ecr_lifecycle_policy.default will be created
  + resource "aws_ecr_lifecycle_policy" "default" {
      + id          = (known after apply)
      + policy      = jsonencode(
            {
              + rules = [
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + description  = "Rotate images when reach 50 images stored for hot-fixed images"
                      + rulePriority = 1
                      + selection    = {
                          + countNumber   = 50
                          + countType     = "imageCountMoreThan"
                          + tagPrefixList = [
                              + "candidate",
                              + "release",
                              + "v",
                            ]
                          + tagStatus     = "tagged"
                        }
                    },
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + description  = "Rotate images when reach 50 images stored for production images"
                      + rulePriority = 2
                      + selection    = {
                          + countNumber   = 50
                          + countType     = "imageCountMoreThan"
                          + tagPrefixList = [
                              + "release",
                              + "v",
                            ]
                          + tagStatus     = "tagged"
                        }
                    },
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + description  = "Rotate images when reach 50 images stored for sole production tags"
                      + rulePriority = 3
                      + selection    = {
                          + countNumber   = 50
                          + countType     = "imageCountMoreThan"
                          + tagPrefixList = [
                              + "v",
                            ]
                          + tagStatus     = "tagged"
                        }
                    },
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + description  = "Rotate images when reach 50 images stored for solo release tags"
                      + rulePriority = 4
                      + selection    = {
                          + countNumber   = 50
                          + countType     = "imageCountMoreThan"
                          + tagPrefixList = [
                              + "release",
                            ]
                          + tagStatus     = "tagged"
                        }
                    },
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + description  = "Rotate images when reach 50 images stored for candidate tags"
                      + rulePriority = 5
                      + selection    = {
                          + countNumber   = 50
                          + countType     = "imageCountMoreThan"
                          + tagPrefixList = [
                              + "candidate",
                            ]
                          + tagStatus     = "tagged"
                        }
                    },
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + description  = "Rotate images when reach 50 images stored for job images"
                      + rulePriority = 6
                      + selection    = {
                          + countNumber   = 50
                          + countType     = "imageCountMoreThan"
                          + tagPrefixList = [
                              + "job",
                            ]
                          + tagStatus     = "tagged"
                        }
                    },
                  + {
                      + action       = {
                          + type = "expire"
                        }
                      + description  = "Rotate image any other images"
                      + rulePriority = 7
                      + selection    = {
                          + countNumber = 50
                          + countType   = "imageCountMoreThan"
                          + tagStatus   = "any"
                        }
                    },
                ]
            }
        )
      + registry_id = (known after apply)
      + repository  = "sandbox/atlantis"
    }

  # module.atlantis.aws_ecr_repository.default will be created
  + resource "aws_ecr_repository" "default" {
      + arn                  = (known after apply)
      + id                   = (known after apply)
      + image_tag_mutability = "MUTABLE"
      + name                 = "sandbox/atlantis"
      + registry_id          = (known after apply)
      + repository_url       = (known after apply)
      + tags                 = {
          + "Name"        = "production-atlantis"
          + "environment" = "production"
          + "repo"        = "aws-sandbox-terraform/production/roles/atlantis"
          + "role"        = "atlantis"
          + "team"        = "ops"
        }
      + tags_all             = {
          + "Name"        = "production-atlantis"
          + "environment" = "production"
          + "repo"        = "aws-sandbox-terraform/production/roles/atlantis"
          + "role"        = "atlantis"
          + "team"        = "ops"
        }

      + image_scanning_configuration {
          + scan_on_push = true
        }
    }

  # module.atlantis.aws_ecr_repository_policy.cross_account_get_access[0] will be created
  + resource "aws_ecr_repository_policy" "cross_account_get_access" {
      + id          = (known after apply)
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = [
                          + "ecr:ListImages",
                          + "ecr:GetrepositoryPolicy",
                          + "ecr:GetDownloadUrlForLayer",
                          + "ecr:GetAuthorizationToken",
                          + "ecr:DescribeRepositories",
                          + "ecr:DescribeImages",
                          + "ecr:BatchGetImage",
                          + "ecr:BatchCheckLayerAvailability",
                        ]
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::562495469185:root"
                        }
                      + Sid       = "AllowXAccountPush"
                    },
                  + {
                      + Action    = [
                          + "ecr:SetRepositoryPolicy",
                          + "ecr:GetRepositoryPolicy",
                          + "ecr:GetDownloadUrlForLayer",
                          + "ecr:BatchGetImage",
                        ]
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "lambda.amazonaws.com"
                        }
                      + Sid       = "LambdaECRImageRetrievalPolicy"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + registry_id = (known after apply)
      + repository  = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.


```
</details>
