### PR TITLE
116 - introduce a service user for automation and integration purposes

### DIFF
--- a/bastion/global/global/groups.tf
+++ b/bastion/global/global/groups.tf
@@ -48,3 +48,21 @@ resource "aws_iam_group_policy_attachment" "force_mfa" {
   group      = aws_iam_group.sandbox.name
   policy_arn = aws_iam_policy.force_mfa.arn
 }
+
+##
+# Automation
+#
+resource "aws_iam_group" "automation" {
+  name = "automation"
+  path = "/terraform/"
+}
+
+resource "aws_iam_group_membership" "automation" {
+  name = "automation-group-membership"
+
+  users = [
+    aws_iam_user.automation_user.name,
+  ]
+
+  group = aws_iam_group.automation.name
+}

--- a/bastion/global/global/labels.tf
+++ b/bastion/global/global/labels.tf
@@ -24,3 +24,9 @@ module "deactivated_label" {
   context    = module.label.context
   attributes = ["deactivated"]
 }
+
+module "automation_user_label" {
+  source  = "../../../modules/base/label/v1"
+  context = module.label.context
+  name    = "automation"
+}

--- a/bastion/global/global/locals.tf
+++ b/bastion/global/global/locals.tf
@@ -2,6 +2,8 @@ locals {
   role_name = "global"
   team      = "ops"
 
+  automation_username = "automation"
+
   security_hub_enabled = false
 
   config_recorder_enabled            = false
@@ -22,4 +24,13 @@ locals {
       aws_iam_policy.ops_bastion_role_iam.arn,
     ]
   }
+
+  automation_policies = {
+    automation_bastion_policy_arns = {
+      readonly    = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+      permissions = aws_iam_policy.automation_permissions.arn
+      secrets     = aws_iam_policy.automation_secrets.arn
+    }
+  }
+
 }

--- a/bastion/global/global/policies.tf
+++ b/bastion/global/global/policies.tf
@@ -304,3 +304,32 @@ resource "aws_iam_policy" "deactivated_user" {
   name   = module.deactivated_label.id
   policy = data.aws_iam_policy_document.deactivated_permissions.json
 }
+
+### AUTOMATION ###
+
+resource "aws_iam_policy" "automation_permissions" {
+  name   = module.automation_user_label.id
+  policy = data.aws_iam_policy_document.automation_permissions.json
+}
+
+data "aws_iam_policy_document" "automation_permissions" {
+  statement {
+    sid = "AllowAutomationMOBBucket"
+    actions = [
+      "s3:DeleteObject",
+      "s3:Get*",
+      "s3:List*",
+      "s3:PutObject",
+      "s3:AbortMultipartUpload",
+    ]
+
+    resources = [
+      "arn:aws:s3:::mob-server-backups/",
+      "arn:aws:s3:::mob-server-backups/*",
+    ]
+  }
+}
+
+
+
+### END AUTOMATION ###

--- a/bastion/global/global/s3.tf
+++ b/bastion/global/global/s3.tf
@@ -9,13 +9,7 @@ module "backup" {
   transition_to_onezone_ia_days = "30"
   transition_to_glacier_days    = "90"
 
-  acl_policy_grants = [
-    {
-      id          = data.aws_canonical_user_id.current.id
-      type        = "CanonicalUser"
-      permissions = "FULL_CONTROL"
-    }
-  ]
+  acl_policy_grants = []
 
   providers = {
     aws.src = aws

--- a/bastion/global/global/s3.tf
+++ b/bastion/global/global/s3.tf
@@ -9,11 +9,21 @@ module "backup" {
   transition_to_onezone_ia_days = "30"
   transition_to_glacier_days    = "90"
 
+  acl_policy_grants = [
+    {
+      id          = data.aws_canonical_user_id.current.id
+      type        = "CanonicalUser"
+      permissions = "FULL_CONTROL"
+    }
+  ]
+
   providers = {
     aws.src = aws
     aws.dst = aws.west
   }
 }
+
+data "aws_canonical_user_id" "current" {}
 
 data "aws_iam_policy_document" "private_backups_policy" {
 

--- a/bastion/global/global/users.tf
+++ b/bastion/global/global/users.tf
@@ -11,3 +11,70 @@ module "dmitry_rendov" {
     aws.production = aws.production
   }
 }
+
+### CI/CD ###
+
+resource "aws_iam_user" "automation_user" {
+  name          = local.automation_username
+  path          = "/terraform/"
+  force_destroy = true
+  tags          = module.automation_user_label.tags
+}
+
+resource "aws_iam_user_policy_attachment" "automation_user_policies" {
+  for_each   = local.automation_policies["automation_bastion_policy_arns"]
+  user       = aws_iam_user.automation_user.name
+  policy_arn = each.value
+  depends_on = [
+    aws_iam_policy.automation_permissions,
+    aws_iam_policy.automation_secrets,
+  ]
+}
+
+### Give Machine user power
+
+data "aws_iam_policy_document" "automation_secrets" {
+  statement {
+    actions   = ["ssm:GetParameter", "ssm:GetParameters"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "ssm:ResourceTag/role"
+      values   = [local.automation_username]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "ssm:ResourceTag/environment"
+      values   = [var.account_name]
+    }
+
+    effect = "Allow"
+  }
+
+  dynamic "statement" {
+    for_each = aws_iam_user.automation_user.*.name
+    content {
+      actions   = ["ssm:GetParameter", "ssm:GetParameters"]
+      resources = ["*"]
+
+      condition {
+        test     = "StringEquals"
+        variable = "ssm:ResourceTag/username"
+        values   = [statement.value]
+      }
+    }
+  }
+
+}
+
+resource "aws_iam_policy" "automation_secrets" {
+  name        = "${module.automation_user_label.id}-secrets"
+  description = "Machine user policy to read its secrets"
+  policy      = data.aws_iam_policy_document.automation_secrets.json
+  tags        = module.automation_user_label.tags
+}
+
+
+### END CI/CD ##

--- a/global-variables.tf.json
+++ b/global-variables.tf.json
@@ -131,6 +131,10 @@
       "default": "mob-terraform-state",
       "description": "Terraform remote s3 backend bucket name"
     },
+    "terraform_remote_state_mob_bucket": {
+      "default": "mob-server-backups",
+      "description": "Terraform remote serverless s3 bucket for production"
+    },
     "terraform_remote_state_region": {
       "default": "us-east-1",
       "description": "Terraform remote s3 storage region"

--- a/modules/base/s3-bucket/v3/main.tf
+++ b/modules/base/s3-bucket/v3/main.tf
@@ -1,6 +1,10 @@
 data "aws_caller_identity" "current" {
 }
 
+data "aws_canonical_user_id" "current" {
+  provider = aws.src
+}
+
 data "aws_caller_identity" "src" {
   provider = aws.src
 }
@@ -105,7 +109,7 @@ resource "aws_s3_bucket_acl" "bucket" {
         }
       }
       owner {
-        id = data.aws_caller_identity.current.account_id
+        id = data.aws_canonical_user_id.current.id
       }
     }
   }


### PR DESCRIPTION
Also, fixed S3 bucket ACL part

<details><summary>Show Terraform plan Output</summary>

```diff
Terraform will perform the following actions:

  # data.aws_iam_policy_document.automation_secrets will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "automation_secrets"  {
      + id            = (known after apply)
      + json          = (known after apply)
      + minified_json = (known after apply)

      + statement {
          + actions   = [
              + "ssm:GetParameter",
              + "ssm:GetParameters",
            ]
          + effect    = "Allow"
          + resources = [
              + "*",
            ]

          + condition {
              + test     = "StringEquals"
              + values   = [
                  + "automation",
                ]
              + variable = "ssm:ResourceTag/role"
            }
          + condition {
              + test     = "StringEquals"
              + values   = [
                  + "bastion",
                ]
              + variable = "ssm:ResourceTag/environment"
            }
        }
      + statement {
          + actions   = [
              + "ssm:GetParameter",
              + "ssm:GetParameters",
            ]
          + resources = [
              + "*",
            ]

          + condition {
              + test     = "StringEquals"
              + values   = [
                  + "automation",
                ]
              + variable = "ssm:ResourceTag/username"
            }
        }
    }

  # aws_iam_group.automation will be created
  + resource "aws_iam_group" "automation" {
      + arn       = (known after apply)
      + id        = (known after apply)
      + name      = "automation"
      + path      = "/terraform/"
      + unique_id = (known after apply)
    }

  # aws_iam_group_membership.automation will be created
  + resource "aws_iam_group_membership" "automation" {
      + group = "automation"
      + id    = (known after apply)
      + name  = "automation-group-membership"
      + users = [
          + "automation",
        ]
    }

  # aws_iam_policy.automation_permissions will be created
  + resource "aws_iam_policy" "automation_permissions" {
      + arn              = (known after apply)
      + attachment_count = (known after apply)
      + id               = (known after apply)
      + name             = "default-automation"
      + name_prefix      = (known after apply)
      + path             = "/"
      + policy           = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "s3:PutObject",
                          + "s3:List*",
                          + "s3:Get*",
                          + "s3:DeleteObject",
                          + "s3:AbortMultipartUpload",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:s3:::mob-server-backups/*",
                          + "arn:aws:s3:::mob-server-backups/",
                        ]
                      + Sid      = "AllowAutomationMOBBucket"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id        = (known after apply)
      + tags_all         = (known after apply)
    }

  # aws_iam_policy.automation_secrets will be created
  + resource "aws_iam_policy" "automation_secrets" {
      + arn              = (known after apply)
      + attachment_count = (known after apply)
      + description      = "Machine user policy to read its secrets"
      + id               = (known after apply)
      + name             = "default-automation-secrets"
      + name_prefix      = (known after apply)
      + path             = "/"
      + policy           = (known after apply)
      + policy_id        = (known after apply)
      + tags             = {
          + "Name"        = "default-automation"
          + "environment" = "default"
          + "repo"        = "aws-sandbox-terraform/bastion/global/global"
          + "role"        = "automation"
          + "team"        = "ops"
        }
      + tags_all         = {
          + "Name"        = "default-automation"
          + "environment" = "default"
          + "repo"        = "aws-sandbox-terraform/bastion/global/global"
          + "role"        = "automation"
          + "team"        = "ops"
        }
    }

  # aws_iam_user.automation_user will be created
  + resource "aws_iam_user" "automation_user" {
      + arn           = (known after apply)
      + force_destroy = true
      + id            = (known after apply)
      + name          = "automation"
      + path          = "/terraform/"
      + tags          = {
          + "Name"        = "default-automation"
          + "environment" = "default"
          + "repo"        = "aws-sandbox-terraform/bastion/global/global"
          + "role"        = "automation"
          + "team"        = "ops"
        }
      + tags_all      = {
          + "Name"        = "default-automation"
          + "environment" = "default"
          + "repo"        = "aws-sandbox-terraform/bastion/global/global"
          + "role"        = "automation"
          + "team"        = "ops"
        }
      + unique_id     = (known after apply)
    }

  # aws_iam_user_policy_attachment.automation_user_policies["permissions"] will be created
  + resource "aws_iam_user_policy_attachment" "automation_user_policies" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + user       = "automation"
    }

  # aws_iam_user_policy_attachment.automation_user_policies["readonly"] will be created
  + resource "aws_iam_user_policy_attachment" "automation_user_policies" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
      + user       = "automation"
    }

  # aws_iam_user_policy_attachment.automation_user_policies["secrets"] will be created
  + resource "aws_iam_user_policy_attachment" "automation_user_policies" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + user       = "automation"
    }

  # module.backup.aws_s3_bucket_acl.bucket[0] will be updated in-place
  ~ resource "aws_s3_bucket_acl" "bucket" {
      - acl    = "private" -> null
        id     = "mob-private-backups,private"
        # (2 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 8 to add, 1 to change, 0 to destroy.
=

Apply this saved plan: make apply-saved-plan

=

```
</details>
